### PR TITLE
fix: dependencia faltante commitlint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2228,6 +2228,15 @@
         }
       }
     },
+    "@commitlint/config-conventional": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-11.0.0.tgz",
+      "integrity": "sha512-SNDRsb5gLuDd2PL83yCOQX6pE7gevC79UPFx+GLbLfw6jGnnbO9/tlL76MLD8MOViqGbo7ZicjChO9Gn+7tHhA==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-conventionalcommits": "^4.3.1"
+      }
+    },
     "@commitlint/ensure": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-11.0.0.tgz",
@@ -7785,6 +7794,17 @@
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.4.0.tgz",
+      "integrity": "sha512-ybvx76jTh08tpaYrYn/yd0uJNLt5yMrb1BphDe4WBredMlvPisvMghfpnJb6RmRNcqXeuhR6LfGZGewbkRm9yA==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
+    "@commitlint/config-conventional": "^11.0.0",
     "@tailwindcss/custom-forms": "0.2.1",
     "all-contributors-cli": "^6.19.0",
     "autoprefixer": "9.8.6",


### PR DESCRIPTION
**Descripción del cambio**:
Añadí la dependencia de `@commitlint/config-conventional`

![image](https://user-images.githubusercontent.com/20668624/96825808-9c982a80-13f7-11eb-90a0-44c621697c52.png)

Al parecer es necesaria la [dependencia](https://github.com/conventional-changelog/commitlint#getting-started)


**Razón del cambio**:
Estaba presentandose el siguiente error:
```
husky > commit-msg (node v12.18.4)
I:\Code\web\node_modules\@commitlint\cli\lib\cli.js:100
        throw err;
        ^

Error: Cannot find module "@commitlint/config-conventional" from "I:\Code\web"
    at resolveId (I:\Code\web\node_modules\←[4m@commitlint←[24m\resolve-extends\lib\index.js:97:17)
    at resolveConfig (I:\Code\web\node_modules\←[4m@commitlint←[24m\resolve-extends\lib\index.js:81:26)
    at I:\Code\web\node_modules\←[4m@commitlint←[24m\resolve-extends\lib\index.js:41:26
    at Array.reduce (<anonymous>)
    at loadExtends (I:\Code\web\node_modules\←[4m@commitlint←[24m\resolve-extends\lib\index.js:39:16)
    at Object.resolveExtends [as default] (I:\Code\web\node_modules\←[4m@commitlint←[24m\resolve-extends\lib\index.js:25:22)
    at Object.load [as default] (I:\Code\web\node_modules\←[4m@commitlint←[24m\load\lib\load.js:38:47)
    at async main (I:\Code\web\node_modules\←[4m@commitlint←[24m\cli\lib\cli.js:126:20) {
  code: ←[32m'MODULE_NOT_FOUND'←[39m
}
husky > commit-msg hook failed (add --no-verify to bypass)
```

**Captura**:
![image](https://user-images.githubusercontent.com/20668624/96825778-85f1d380-13f7-11eb-8948-fad5ee559026.png)

